### PR TITLE
Fix installation requirements error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "torch", "ninja", "packaging"]
+requires = ["setuptools", "torch", "ninja", "packaging", "wheel"]
 
 [tool.setuptools.packages.find]
 exclude = [
@@ -15,7 +15,7 @@ exclude = [
 
 [project]
 name = "fast_hadamard_transform"
-version = 1.0.5
+version = "1.0.5"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools", "torch", "ninja", "packaging"]
+
+[tool.setuptools.packages.find]
+exclude = [
+    "build",
+    "csrc",
+    "include",
+    "tests",
+    "dist",
+    "docs",
+    "benchmarks",
+    "fast_hadamard_transform.egg-info",
+]
+
+[project]
+name = "fast_hadamard_transform"
+version = 1.0.5
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: Unix",
+]
+authors = [
+  { name="Tri Dao", email="tri@tridao.me" },
+]
+readme = "README.md"
+description = "Fast Hadamard Transform in CUDA, with a PyTorch interface"
+requires-python = ">=3.7"
+dependencies = [
+    "torch",
+    "scipy"
+]
+
+[project.urls]
+Homepage = "https://github.com/Dao-AILab/fast-hadamard-transform"
+Issues = "https://github.com/Dao-AILab/fast-hadamard-transform/issues"

--- a/setup.py
+++ b/setup.py
@@ -222,8 +222,6 @@ class CachedWheelsCommand(_bdist_wheel):
 
 
 setup(
-    name=PACKAGE_NAME,
-    version=get_package_version(),
     packages=find_packages(
         exclude=(
             "build",
@@ -236,27 +234,10 @@ setup(
             "fast_hadamard_transform.egg-info",
         )
     ),
-    author="Tri Dao",
-    author_email="tri@tridao.me",
-    description="Fast Hadamard Transform in CUDA, with a PyTorch interface",
-    long_description=long_description,
-    long_description_content_type="text/markdown",
-    url="https://github.com/Dao-AILab/fast-hadamard-transform",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: BSD License",
-        "Operating System :: Unix",
-    ],
     ext_modules=ext_modules,
     cmdclass={"bdist_wheel": CachedWheelsCommand, "build_ext": BuildExtension}
     if ext_modules
     else {
         "bdist_wheel": CachedWheelsCommand,
     },
-    python_requires=">=3.7",
-    install_requires=[
-        "torch",
-        "packaging",
-        "ninja",
-    ],
 )


### PR DESCRIPTION
Fixes #4 

Main problem with using only setup.py is that if you have installation requirements running setup.py on a fresh environment is going to cause error because you are trying to import those dependencies before calling setup function.

With the addition of pyproject.toml file you can install those dependencies before running setup.py file. So you can install the package with only running 
```
pip install .
```
or 
```
pip install git+https://github.com/Dao-AILab/fast-hadamard-transform
```

If you want to try before merging  you can just run this on a fresh environment:
```
pip install git+https://github.com/osbm/fast-hadamard-transform
```
