### PR TITLE
Update setup.py with blackwell support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,10 @@ if not SKIP_CUDA_BUILD:
     if bare_metal_version >= Version("11.8"):
         cc_flag.append("-gencode")
         cc_flag.append("arch=compute_90,code=sm_90")
+    if bare_metal_version >= Version("12.0"):
+        cc_flag.append("-gencode")
+        cc_flag.append("arch=compute_100,code=sm_100")
+
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
     # torch._C._GLIBCXX_USE_CXX11_ABI


### PR DESCRIPTION
This PR updates setup.py to ensure Blackwell (SM100) support.
With current code, buildiing on Blackwell will succeed, but when running, you will get:
~~~
torch.AcceleratorError: CUDA error: no kernel image is available for execution on the device
~~~

this is because the current setup.py maxes out with Hopper (SM90). 

Besides building with this PR, do note that to run on Blackwell, you must also build with and run on PyTorch Nightly.
Pytorch 2.7 stable does not support Blackwell and may not give a clear error as to the failure.

Verify PyTorch support with: 
~~~
python3 -c "import torch; print(f'PyTorch version: {torch.__version__}'); print(f'CUDA version: {torch.version.cuda}'); print(f'PyTorch CUDA architectures: {torch.cuda.get_arch_list()}')"
~~~

