### PR TITLE
fix: mising import

### DIFF
--- a/benchmarks/benchmark_fast_hadamard_transform.py
+++ b/benchmarks/benchmark_fast_hadamard_transform.py
@@ -2,6 +2,7 @@ import torch
 
 from flash_attn.utils.benchmark import benchmark_forward, pytorch_profiler
 from fast_hadamard_transform import hadamard_transform
+from fast_hadamard_transform.fast_hadamard_transform_interface import hadamard_transform_12N
 from fast_hadamard_transform.fast_hadamard_transform_interface import hadamard_transform_20N
 from fast_hadamard_transform.fast_hadamard_transform_interface import hadamard_transform_28N
 


### PR DESCRIPTION
Add missing import in bencharm script

```bash
$ python benchmarks/benchmark_fast_hadamard_transform.py 

...
Traceback (most recent call last):
  File "/fast-hadamard-transform/benchmarks/benchmark_fast_hadamard_transform.py", line 24, in <module>
    benchmark_forward(hadamard_transform_12N, x, 1.0, desc="Hadamard transform 12N")
                      ^^^^^^^^^^^^^^^^^^^^^^
NameError: name 'hadamard_transform_12N' is not defined. Did you mean: 'hadamard_transform_20N'?
```