### PR TITLE
Multi-backend support (ROCm and MUSA)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+
+# hipified files
+*.hip
+*_hip.*

--- a/benchmarks/benchmark_fast_hadamard_transform.py
+++ b/benchmarks/benchmark_fast_hadamard_transform.py
@@ -14,6 +14,8 @@ seqlen = 2048
 dim = 16384 * 2
 dtype = torch.float16
 device = "cuda"
+if hasattr(torch, "musa"):
+    device = "musa"
 
 torch.random.manual_seed(0)
 x = torch.randn(batch_size, seqlen, dim, dtype=dtype, device=device)

--- a/csrc/fast_hadamard_transform.cpp
+++ b/csrc/fast_hadamard_transform.cpp
@@ -2,11 +2,17 @@
  * Copyright (c) 2023, Tri Dao.
  ******************************************************************************/
 
+#ifndef USE_MUSA
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#else
+#include "torch_musa/csrc/aten/musa/MUSAContext.h"
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#endif
 #include <torch/extension.h>
 #include <vector>
 
+#include "vendor.h"
 #include "fast_hadamard_transform.h"
 
 #define CHECK_SHAPE(x, ...) TORCH_CHECK(x.sizes() == torch::IntArrayRef({__VA_ARGS__}), #x " must have shape (" #__VA_ARGS__ ")")
@@ -74,7 +80,11 @@ fast_hadamard_transform(at::Tensor &x, float scale) {
     auto input_type = x.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
 
+#ifndef USE_MUSA
     TORCH_CHECK(x.is_cuda());
+#else
+    TORCH_CHECK(x.is_privateuseone());
+#endif
 
     const auto shapes_og = x.sizes();
     const int dim_og = x.size(-1);
@@ -117,7 +127,11 @@ fast_hadamard_transform_12N(at::Tensor &x, float scale) {
     auto input_type = x.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
 
+#ifndef USE_MUSA
     TORCH_CHECK(x.is_cuda());
+#else
+    TORCH_CHECK(x.is_privateuseone());
+#endif
 
     const auto shapes_og = x.sizes();
     const int dim_og = x.size(-1);
@@ -160,7 +174,11 @@ fast_hadamard_transform_20N(at::Tensor &x, float scale) {
     auto input_type = x.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
 
+#ifndef USE_MUSA
     TORCH_CHECK(x.is_cuda());
+#else
+    TORCH_CHECK(x.is_privateuseone());
+#endif
 
     const auto shapes_og = x.sizes();
     const int dim_og = x.size(-1);
@@ -203,7 +221,11 @@ fast_hadamard_transform_28N(at::Tensor &x, float scale) {
     auto input_type = x.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
 
+#ifndef USE_MUSA
     TORCH_CHECK(x.is_cuda());
+#else
+    TORCH_CHECK(x.is_privateuseone());
+#endif
 
     const auto shapes_og = x.sizes();
     const int dim_og = x.size(-1);
@@ -246,7 +268,11 @@ fast_hadamard_transform_40N(at::Tensor &x, float scale) {
     auto input_type = x.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
 
+#ifndef USE_MUSA
     TORCH_CHECK(x.is_cuda());
+#else
+    TORCH_CHECK(x.is_privateuseone());
+#endif
 
     const auto shapes_og = x.sizes();
     const int dim_og = x.size(-1);

--- a/csrc/fast_hadamard_transform_common.h
+++ b/csrc/fast_hadamard_transform_common.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <cuda_bf16.h>
-#include <cuda_fp16.h>
+#include "vendor.h"
 
 #define FULL_MASK 0xffffffff
 

--- a/csrc/fast_hadamard_transform_gpu.cu
+++ b/csrc/fast_hadamard_transform_gpu.cu
@@ -6,8 +6,13 @@
 
 #include <c10/util/BFloat16.h>
 #include <c10/util/Half.h>
+#ifndef USE_MUSA
 #include <c10/cuda/CUDAException.h>  // For C10_CUDA_CHECK and C10_CUDA_KERNEL_LAUNCH_CHECK
+#else
+#include "torch_musa/csrc/core/MUSAException.h"  // For C10_MUSA_CHECK and C10_MUSA_KERNEL_LAUNCH_CHECK
+#endif
 
+#include "vendor.h"
 #include "fast_hadamard_transform.h"
 #include "fast_hadamard_transform_common.h"
 #include "fast_hadamard_transform_special.h"
@@ -28,7 +33,7 @@ struct fast_hadamard_transform_kernel_traits {
     using vec_t = typename BytesToType<kNBytes * kNElts>::Type;
     static constexpr int kNChunks = N / (kNElts * kNThreads);
     // We don't want to use more than 32 KB of shared memory.
-    static constexpr int kSmemExchangeSize = std::min(N * 4, 32 * 1024);
+    static constexpr int kSmemExchangeSize = MIN(N * 4, 32 * 1024);
     static constexpr int kNExchangeRounds = N * 4 / kSmemExchangeSize;
     static_assert(kNExchangeRounds * kSmemExchangeSize == N * 4);
     static constexpr int kSmemSize = kSmemExchangeSize;
@@ -51,7 +56,7 @@ struct fast_hadamard_transform_12N_kernel_traits {
     static constexpr int kNChunks = N / (kNElts * kNThreads);
     static_assert(kNChunks == 12);
     // We don't want to use more than 24 KB of shared memory.
-    static constexpr int kSmemExchangeSize = std::min(N * 4, 24 * 1024);
+    static constexpr int kSmemExchangeSize = MIN(N * 4, 24 * 1024);
     static constexpr int kNExchangeRounds = N * 4 / kSmemExchangeSize;
     static_assert(kNExchangeRounds * kSmemExchangeSize == N * 4);
     static constexpr int kSmemSize = kSmemExchangeSize;
@@ -74,7 +79,7 @@ struct fast_hadamard_transform_20N_kernel_traits {
     static constexpr int kNChunks = N / (kNElts * kNThreads);
     static_assert(kNChunks == 20);
     // We don't want to use more than 40 KB of shared memory.
-    static constexpr int kSmemExchangeSize = std::min(N * 4, 40 * 1024);
+    static constexpr int kSmemExchangeSize = MIN(N * 4, 40 * 1024);
     static constexpr int kNExchangeRounds = N * 4 / kSmemExchangeSize;
     static_assert(kNExchangeRounds * kSmemExchangeSize == N * 4);
     static constexpr int kSmemSize = kSmemExchangeSize;
@@ -97,7 +102,7 @@ struct fast_hadamard_transform_28N_kernel_traits {
     static constexpr int kNChunks = N / (kNElts * kNThreads);
     static_assert(kNChunks == 28);
     // We don't want to use more than 28 KB of shared memory.
-    static constexpr int kSmemExchangeSize = std::min(N * 4, 28 * 1024);
+    static constexpr int kSmemExchangeSize = MIN(N * 4, 28 * 1024);
     static constexpr int kNExchangeRounds = N * 4 / kSmemExchangeSize;
     static_assert(kNExchangeRounds * kSmemExchangeSize == N * 4);
     static constexpr int kSmemSize = kSmemExchangeSize;
@@ -120,7 +125,7 @@ struct fast_hadamard_transform_40N_kernel_traits {
     static constexpr int kNChunks = N / (kNElts * kNThreads);
     static_assert(kNChunks == 40);
     // We don't want to use more than 40 KB of shared memory.
-    static constexpr int kSmemExchangeSize = std::min(N * 4, 40 * 1024);
+    static constexpr int kSmemExchangeSize = MIN(N * 4, 40 * 1024);
     static constexpr int kNExchangeRounds = N * 4 / kSmemExchangeSize;
     static_assert(kNExchangeRounds * kSmemExchangeSize == N * 4);
     static constexpr int kSmemSize = kSmemExchangeSize;
@@ -163,7 +168,7 @@ void fast_hadamard_transform_kernel(HadamardParamsBase params) {
 
     constexpr int kLogNElts = cilog2(Ktraits::kNElts);
     static_assert(1 << kLogNElts == kNElts, "kNElts must be a power of 2");
-    constexpr int kWarpSize = std::min(kNThreads, 32);
+    constexpr int kWarpSize = MIN(kNThreads, WARP_SIZE);
     constexpr int kLogWarpSize = cilog2(kWarpSize);
     static_assert(1 << kLogWarpSize == kWarpSize, "Warp size must be a power of 2");
     constexpr int kNWarps = kNThreads / kWarpSize;
@@ -234,10 +239,12 @@ void fast_hadamard_transform_launch(HadamardParamsBase &params, cudaStream_t str
     constexpr int kSmemSize = Ktraits::kSmemSize;
     dim3 grid(params.batch);
     auto kernel = &fast_hadamard_transform_kernel<Ktraits>;
+#ifndef USE_ROCM
     if (kSmemSize >= 48 * 1024) {
         C10_CUDA_CHECK(cudaFuncSetAttribute(
             kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
         }
+#endif
     kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -279,10 +286,12 @@ void fast_hadamard_transform_12N_launch(HadamardParamsBase &params, cudaStream_t
     constexpr int kSmemSize = Ktraits::kSmemSize;
     dim3 grid(params.batch);
     auto kernel = &fast_hadamard_transform_kernel<Ktraits>;
+#ifndef USE_ROCM
     if (kSmemSize >= 48 * 1024) {
         C10_CUDA_CHECK(cudaFuncSetAttribute(
             kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
         }
+#endif
     kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -307,7 +316,7 @@ void fast_hadamard_transform_12N_cuda(HadamardParamsBase &params, cudaStream_t s
         fast_hadamard_transform_12N_launch<128, 9, input_t>(params, stream);
     } else if (params.log_N == 10) {
         fast_hadamard_transform_12N_launch<256, 10, input_t>(params, stream);
-    } 
+    }
 }
 
 template<int kNThreads, int kLogN, typename input_t>
@@ -316,10 +325,12 @@ void fast_hadamard_transform_20N_launch(HadamardParamsBase &params, cudaStream_t
     constexpr int kSmemSize = Ktraits::kSmemSize;
     dim3 grid(params.batch);
     auto kernel = &fast_hadamard_transform_kernel<Ktraits>;
+#ifndef USE_ROCM
     if (kSmemSize >= 48 * 1024) {
         C10_CUDA_CHECK(cudaFuncSetAttribute(
             kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
         }
+#endif
     kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -353,10 +364,12 @@ void fast_hadamard_transform_28N_launch(HadamardParamsBase &params, cudaStream_t
     constexpr int kSmemSize = Ktraits::kSmemSize;
     dim3 grid(params.batch);
     auto kernel = &fast_hadamard_transform_kernel<Ktraits>;
+#ifndef USE_ROCM
     if (kSmemSize >= 48 * 1024) {
         C10_CUDA_CHECK(cudaFuncSetAttribute(
             kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
         }
+#endif
     kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
@@ -390,10 +403,12 @@ void fast_hadamard_transform_40N_launch(HadamardParamsBase &params, cudaStream_t
     constexpr int kSmemSize = Ktraits::kSmemSize;
     dim3 grid(params.batch);
     auto kernel = &fast_hadamard_transform_kernel<Ktraits>;
+#ifndef USE_ROCM
     if (kSmemSize >= 48 * 1024) {
         C10_CUDA_CHECK(cudaFuncSetAttribute(
             kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
         }
+#endif
     kernel<<<grid, Ktraits::kNThreads, kSmemSize, stream>>>(params);
     C10_CUDA_KERNEL_LAUNCH_CHECK();
 }

--- a/csrc/vendor.h
+++ b/csrc/vendor.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#if !defined(USE_MUSA) && !defined(USE_ROCM)
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+#define WARP_SIZE 32
+#define MIN(A, B) std::min((A), (B))
+#elif defined(USE_MUSA)
+#include <musa_bf16.h>
+#include <musa_fp16.h>
+
+#define WARP_SIZE 32
+#define MIN(A, B) std::min((A), (B))
+#define C10_CUDA_CHECK C10_MUSA_CHECK
+#define C10_CUDA_KERNEL_LAUNCH_CHECK C10_MUSA_KERNEL_LAUNCH_CHECK
+#define cudaFuncAttributeMaxDynamicSharedMemorySize musaFuncAttributeMaxDynamicSharedMemorySize
+#define cudaFuncSetAttribute musaFuncSetAttribute
+#define cudaStream_t musaStream_t
+
+#include "torch_musa/csrc/core/MUSAGuard.h"
+#include "torch_musa/csrc/core/MUSAStream.h"
+namespace at {
+namespace cuda {
+#ifdef USE_MUSA
+using CUDAGuard = at::musa::MUSAGuard;
+inline at::musa::MUSAStream getCurrentCUDAStream() {
+    return at::musa::getCurrentMUSAStream();
+}
+#endif
+} // namespace cuda
+} // namespace at
+#elif defined(USE_ROCM)
+#define WARP_SIZE 64
+#define MIN(A, B) ((A) < (B) ? (A) : (B))
+#define __shfl_xor_sync(MASK, X, OFFSET) __shfl_xor(X, OFFSET)
+#endif // !defined(USE_MUSA) && !defined(USE_ROCM)

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,54 @@
 # Copyright (c) 2023, Tri Dao.
-import sys
-import warnings
-import os
-import re
 import ast
-from pathlib import Path
-from packaging.version import parse, Version
+import os
 import platform
-
-from setuptools import setup, find_packages
+import re
 import subprocess
-
-import urllib.request
+import sys
 import urllib.error
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+import urllib.request
+import warnings
+from enum import Enum, auto
+from pathlib import Path
 
 import torch
-from torch.utils.cpp_extension import (
-    BuildExtension,
-    CppExtension,
-    CUDAExtension,
-    CUDA_HOME,
-)
+from packaging.version import Version, parse
+from setuptools import find_packages, setup
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+
+class Backend(Enum):
+    CUDA = auto()
+    HIP = auto()
+    MUSA = auto()
+
+
+backend = Backend.CUDA
+
+if hasattr(torch, "cuda") and (
+    torch.version.cuda is not None or torch.version.hip is not None
+):
+    from torch.utils.cpp_extension import CUDA_HOME, BuildExtension, CUDAExtension
+
+    if torch.version.hip:
+        backend = Backend.HIP
+
+
+elif hasattr(torch, "musa"):
+    import torch_musa
+    from torch_musa.utils.musa_extension import MUSA_HOME as CUDA_HOME
+    from torch_musa.utils.musa_extension import BuildExtension as MUSABuildExtension
+    from torch_musa.utils.musa_extension import MUSAExtension as CUDAExtension
+
+    class _CustomBuildExtension(MUSABuildExtension):
+        def build_extensions(self):
+            self.compiler.src_extensions += [".cu", ".cuh"]
+
+            super().build_extensions()
+
+    BuildExtension = _CustomBuildExtension
+
+    backend = Backend.MUSA
 
 
 with open("README.md", "r", encoding="utf-8") as fh:
@@ -38,9 +65,13 @@ BASE_WHEEL_URL = "https://github.com/Dao-AILab/fast-hadamard-transform/releases/
 # FORCE_BUILD: Force a fresh build locally, instead of attempting to find prebuilt wheels
 # SKIP_CUDA_BUILD: Intended to allow CI to use a simple `python setup.py sdist` run to copy over raw files, without any cuda compilation
 FORCE_BUILD = os.getenv("FAST_HADAMARD_TRANSFORM_FORCE_BUILD", "FALSE") == "TRUE"
-SKIP_CUDA_BUILD = os.getenv("FAST_HADAMARD_TRANSFORM_SKIP_CUDA_BUILD", "FALSE") == "TRUE"
+SKIP_CUDA_BUILD = (
+    os.getenv("FAST_HADAMARD_TRANSFORM_SKIP_CUDA_BUILD", "FALSE") == "TRUE"
+)
 # For CI, we want the option to build with C++11 ABI since the nvcr images use C++11 ABI
-FORCE_CXX11_ABI = os.getenv("FAST_HADAMARD_TRANSFORM_FORCE_CXX11_ABI", "FALSE") == "TRUE"
+FORCE_CXX11_ABI = (
+    os.getenv("FAST_HADAMARD_TRANSFORM_FORCE_CXX11_ABI", "FALSE") == "TRUE"
+)
 
 
 def get_platform():
@@ -82,7 +113,11 @@ def check_if_cuda_home_none(global_option: str) -> None:
 
 
 def append_nvcc_threads():
-    return ["--threads", os.getenv("NVCC_THREADS") or "4"]
+    if backend == Backend.CUDA:
+        return ["--threads", os.getenv("NVCC_THREADS") or "4"]
+    else:
+        return []
+
 
 cmdclass = {}
 ext_modules = []
@@ -92,29 +127,34 @@ if not SKIP_CUDA_BUILD:
     TORCH_MAJOR = int(torch.__version__.split(".")[0])
     TORCH_MINOR = int(torch.__version__.split(".")[1])
 
-    check_if_cuda_home_none("fast_hadamard_transform")
-    # Check, if CUDA11 is installed for compute capability 8.0
     cc_flag = []
-    if CUDA_HOME is not None:
-        _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
-        if bare_metal_version < Version("11.6"):
-            raise RuntimeError(
-                "fast_hadamard_transform is only supported on CUDA 11.6 and above.  "
-                "Note: make sure nvcc has a supported version by running nvcc -V."
-            )
+    if backend == Backend.CUDA:
+        check_if_cuda_home_none("fast_hadamard_transform")
+        # Check, if CUDA11 is installed for compute capability 8.0
+        if CUDA_HOME is not None:
+            _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
+            if bare_metal_version < Version("11.6"):
+                raise RuntimeError(
+                    "fast_hadamard_transform is only supported on CUDA 11.6 and above.  "
+                    "Note: make sure nvcc has a supported version by running nvcc -V."
+                )
 
-    if bare_metal_version <= Version("12.9"):
+    if backend == Backend.CUDA:
+        if bare_metal_version <= Version("12.9"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_70,code=sm_70")
         cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_70,code=sm_70")
-    cc_flag.append("-gencode")
-    cc_flag.append("arch=compute_80,code=sm_80")
-    if bare_metal_version >= Version("11.8"):
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_90,code=sm_90")
-    if bare_metal_version >= Version("12.8"):
-        cc_flag.append("-gencode")
-        cc_flag.append("arch=compute_100,code=sm_100")
-
+        cc_flag.append("arch=compute_80,code=sm_80")
+        if bare_metal_version >= Version("11.8"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_90,code=sm_90")
+        if bare_metal_version >= Version("12.8"):
+            cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_100,code=sm_100")
+    elif backend == Backend.HIP:
+        cc_flag.append("-DUSE_ROCM=1")
+    elif backend == Backend.MUSA:
+        cc_flag.append("-DUSE_MUSA=1")
 
     # HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
     # torch._C._GLIBCXX_USE_CXX11_ABI
@@ -122,32 +162,52 @@ if not SKIP_CUDA_BUILD:
     if FORCE_CXX11_ABI:
         torch._C._GLIBCXX_USE_CXX11_ABI = True
 
+    cxx_flags = ["-O3"] if backend in (Backend.CUDA, Backend.HIP) else ["force_mcc"]
+    backend_cc = "nvcc" if backend in (Backend.CUDA, Backend.HIP) else "mcc"
+    backend_cc_flags = []
+    if backend == Backend.CUDA or backend == Backend.HIP:
+        backend_cc_flags = [
+            "-O3",
+            "-U__CUDA_NO_HALF_OPERATORS__",
+            "-U__CUDA_NO_HALF_CONVERSIONS__",
+            "-U__CUDA_NO_BFLOAT16_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+            "-U__CUDA_NO_BFLOAT162_OPERATORS__",
+            "-U__CUDA_NO_BFLOAT162_CONVERSIONS__",
+        ]
+        if backend == Backend.CUDA:
+            backend_cc_flags += [
+                "--expt-relaxed-constexpr",
+                "--expt-extended-lambda",
+                "--use_fast_math",
+                "--ptxas-options=-v",
+                "-lineinfo",
+            ]
+    elif backend == Backend.MUSA:
+        backend_cc_flags = [
+            "-O3",
+            "-fPIC",
+            "-std=c++17",
+            "-x",
+            "musa",
+            "-mtgpu",
+            "--cuda-gpu-arch=mp_31",
+            "-fno-strict-aliasing",
+            "-ffast-math",
+            "-Od3",
+            "-fmusa-flush-denormals-to-zero",
+        ]
+
     ext_modules.append(
         CUDAExtension(
             name="fast_hadamard_transform_cuda",
             sources=[
                 "csrc/fast_hadamard_transform.cpp",
-                "csrc/fast_hadamard_transform_cuda.cu",
+                "csrc/fast_hadamard_transform_gpu.cu",
             ],
             extra_compile_args={
-                "cxx": ["-O3"],
-                "nvcc":
-                    [
-                        "-O3",
-                        "-U__CUDA_NO_HALF_OPERATORS__",
-                        "-U__CUDA_NO_HALF_CONVERSIONS__",
-                        "-U__CUDA_NO_BFLOAT16_OPERATORS__",
-                        "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
-                        "-U__CUDA_NO_BFLOAT162_OPERATORS__",
-                        "-U__CUDA_NO_BFLOAT162_CONVERSIONS__",
-                        "--expt-relaxed-constexpr",
-                        "--expt-extended-lambda",
-                        "--use_fast_math",
-                        "--ptxas-options=-v",
-                        "-lineinfo",
-                    ]
-                    + append_nvcc_threads()
-                    + cc_flag,
+                "cxx": cxx_flags,
+                backend_cc: backend_cc_flags + append_nvcc_threads() + cc_flag,
             },
             include_dirs=[this_dir],
         )
@@ -169,11 +229,18 @@ def get_wheel_url():
     # Determine the version numbers that will be used to determine the correct wheel
     # We're using the CUDA version used to build torch, not the one currently installed
     # _, cuda_version_raw = get_cuda_bare_metal_version(CUDA_HOME)
-    torch_cuda_version = parse(torch.version.cuda)
+    backend_versions = {
+        Backend.CUDA: torch.version.cuda,
+        Backend.HIP: torch.version.hip,
+        Backend.MUSA: getattr(torch.version, "musa", None),
+    }
+    torch_cuda_version = parse(backend_versions[backend])
     torch_version_raw = parse(torch.__version__)
     # For CUDA 11, we only compile for CUDA 11.8, and for CUDA 12 we only compile for CUDA 12.2
     # to save CI time. Minor versions should be compatible.
-    torch_cuda_version = parse("11.8") if torch_cuda_version.major == 11 else parse("12.2")
+    torch_cuda_version = (
+        parse("11.8") if torch_cuda_version.major == 11 else parse("12.2")
+    )
     python_version = f"cp{sys.version_info.major}{sys.version_info.minor}"
     platform_name = get_platform()
     fast_hadamard_transform_version = get_package_version()
@@ -252,11 +319,13 @@ setup(
         "Operating System :: Unix",
     ],
     ext_modules=ext_modules,
-    cmdclass={"bdist_wheel": CachedWheelsCommand, "build_ext": BuildExtension}
-    if ext_modules
-    else {
-        "bdist_wheel": CachedWheelsCommand,
-    },
+    cmdclass=(
+        {"bdist_wheel": CachedWheelsCommand, "build_ext": BuildExtension}
+        if ext_modules
+        else {
+            "bdist_wheel": CachedWheelsCommand,
+        }
+    ),
     python_requires=">=3.7",
     install_requires=[
         "torch",

--- a/tests/test_fast_hadamard_transform.py
+++ b/tests/test_fast_hadamard_transform.py
@@ -16,6 +16,8 @@ from fast_hadamard_transform.fast_hadamard_transform_interface import hadamard_t
 # @pytest.mark.parametrize("dim", [256])
 def test_fast_hadamard_transform(dim, dtype):
     device = "cuda"
+    if hasattr(torch, "musa"):
+        device = "musa"
     rtol, atol = (3e-4, 3e-3) if dtype == torch.float32 else (3e-3, 5e-3)
     if dtype == torch.bfloat16:
         rtol, atol = 1e-2, 5e-2


### PR DESCRIPTION
This PR was inspired by https://github.com/Dao-AILab/fast-hadamard-transform/pull/11 and extends it to support multiple backends, including ROCm and MUSA.

Build/install/unit tests all passed on ROCm and MUSA. Please see the logs below for more information.

### Testing Done

#### ROCm 7.0.0 + Torch 2.9.0a0+git7bcbafe
```bash
root@4ba3a2f2f1b5:/sgl-workspace/fast-hadamard-transform# python setup.py install


torch.__version__  = 2.9.0a0+git7bcbafe


/sgl-workspace/fast-hadamard-transform/csrc/vendor.h -> /sgl-workspace/fast-hadamard-transform/csrc/vendor_hip.h [skipped, already hipified]
/sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform.h -> /sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform.h [skipped, no changes]
/sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform.cpp -> /sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_hip.cpp [skipped, already hipified]
/sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_common.h -> /sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_common_hip.h [skipped, already hipified]
/sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_special.h -> /sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_special.h [skipped, no changes]
/sgl-workspace/fast-hadamard-transform/csrc/static_switch.h -> /sgl-workspace/fast-hadamard-transform/csrc/static_switch.h [skipped, no changes]
/sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_gpu.cu -> /sgl-workspace/fast-hadamard-transform/csrc/fast_hadamard_transform_gpu.hip [skipped, already hipified]
Successfully preprocessed all matching files.
Total number of unsupported CUDA function calls: 0


Total number of replaced kernel launches: 5
/opt/venv/lib/python3.10/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
running install
/opt/venv/lib/python3.10/site-packages/setuptools/_distutils/cmd.py:90: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
/opt/venv/lib/python3.10/site-packages/setuptools/_distutils/cmd.py:90: EasyInstallDeprecationWarning: easy_install command is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` and ``easy_install``.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://github.com/pypa/setuptools/issues/917 for details.
        ********************************************************************************

!!
  self.initialize_options()
running bdist_egg
running egg_info
writing fast_hadamard_transform.egg-info/PKG-INFO
writing dependency_links to fast_hadamard_transform.egg-info/dependency_links.txt
writing requirements to fast_hadamard_transform.egg-info/requires.txt
writing top-level names to fast_hadamard_transform.egg-info/top_level.txt
adding license file 'LICENSE'
adding license file 'AUTHORS'
writing manifest file 'fast_hadamard_transform.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
copying fast_hadamard_transform/__init__.py -> build/lib.linux-x86_64-cpython-310/fast_hadamard_transform
copying fast_hadamard_transform/fast_hadamard_transform_interface.py -> build/lib.linux-x86_64-cpython-310/fast_hadamard_transform
running build_ext
building 'fast_hadamard_transform_cuda' extension
ninja: no work to do.
x86_64-linux-gnu-g++ -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -shared -Wl,-O1 -Wl,-Bsymbolic-functions /sgl-workspace/fast-hadamard-transform/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform_gpu.o /sgl-workspace/fast-hadamard-transform/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform_hip.o -L/opt/venv/lib/python3.10/site-packages/torch/lib -L/opt/rocm/lib -L/opt/rocm/hip/lib -L/usr/lib/x86_64-linux-gnu -lc10 -ltorch -ltorch_cpu -ltorch_python -lamdhip64 -lc10_hip -ltorch_hip -o build/lib.linux-x86_64-cpython-310/fast_hadamard_transform_cuda.cpython-310-x86_64-linux-gnu.so
creating build/bdist.linux-x86_64/egg
copying build/lib.linux-x86_64-cpython-310/fast_hadamard_transform_cuda.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/fast_hadamard_transform
copying build/lib.linux-x86_64-cpython-310/fast_hadamard_transform/__init__.py -> build/bdist.linux-x86_64/egg/fast_hadamard_transform
copying build/lib.linux-x86_64-cpython-310/fast_hadamard_transform/fast_hadamard_transform_interface.py -> build/bdist.linux-x86_64/egg/fast_hadamard_transform
byte-compiling build/bdist.linux-x86_64/egg/fast_hadamard_transform/__init__.py to __init__.cpython-310.pyc
byte-compiling build/bdist.linux-x86_64/egg/fast_hadamard_transform/fast_hadamard_transform_interface.py to fast_hadamard_transform_interface.cpython-310.pyc
creating stub loader for fast_hadamard_transform_cuda.cpython-310-x86_64-linux-gnu.so
byte-compiling build/bdist.linux-x86_64/egg/fast_hadamard_transform_cuda.py to fast_hadamard_transform_cuda.cpython-310.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
writing build/bdist.linux-x86_64/egg/EGG-INFO/native_libs.txt
zip_safe flag not set; analyzing archive contents...
__pycache__.fast_hadamard_transform_cuda.cpython-310: module references __file__
creating 'dist/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg
removing '/opt/venv/lib/python3.10/site-packages/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg' (and everything under it)
creating /opt/venv/lib/python3.10/site-packages/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg
Extracting fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg to /opt/venv/lib/python3.10/site-packages
Adding fast-hadamard-transform 1.0.4.post1 to easy-install.pth file

Installed /opt/venv/lib/python3.10/site-packages/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg
Processing dependencies for fast-hadamard-transform==1.0.4.post1
Searching for ninja==1.13.0
Best match: ninja 1.13.0
Adding ninja 1.13.0 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for packaging==25.0
Best match: packaging 25.0
Adding packaging 25.0 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for torch==2.9.0a0+git7bcbafe
Best match: torch 2.9.0a0+git7bcbafe
Adding torch 2.9.0a0+git7bcbafe to easy-install.pth file
Installing torchfrtrace script to /opt/venv/bin
Installing torchrun script to /opt/venv/bin

Using /opt/venv/lib/python3.10/site-packages
Searching for fsspec==2025.3.0
Best match: fsspec 2025.3.0
Adding fsspec 2025.3.0 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for jinja2==3.1.6
Best match: jinja2 3.1.6
Adding jinja2 3.1.6 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for networkx==2.8.8
Best match: networkx 2.8.8
Adding networkx 2.8.8 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for sympy==1.13.3
Best match: sympy 1.13.3
Adding sympy 1.13.3 to easy-install.pth file
Installing isympy script to /opt/venv/bin

Using /opt/venv/lib/python3.10/site-packages
Searching for typing-extensions==4.14.1
Best match: typing-extensions 4.14.1
Adding typing-extensions 4.14.1 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for filelock==3.19.1
Best match: filelock 3.19.1
Adding filelock 3.19.1 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for MarkupSafe==3.0.2
Best match: MarkupSafe 3.0.2
Adding MarkupSafe 3.0.2 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Searching for mpmath==1.3.0
Best match: mpmath 1.3.0
Adding mpmath 1.3.0 to easy-install.pth file

Using /opt/venv/lib/python3.10/site-packages
Finished processing dependencies for fast-hadamard-transform==1.0.4.post1
root@4ba3a2f2f1b5:/sgl-workspace/fast-hadamard-transform# cd tests
root@4ba3a2f2f1b5:/sgl-workspace/fast-hadamard-transform/tests# pytest test_fast_hadamard_transform.py
=================================================================== test session starts ====================================================================
platform linux -- Python 3.10.12, pytest-8.4.1, pluggy-1.6.0
rootdir: /sgl-workspace/fast-hadamard-transform
plugins: langsmith-0.4.31, anyio-4.10.0, asyncio-1.1.0, subtests-0.13.1, xdoctest-1.1.0, flakefinder-1.1.0, hypothesis-5.35.1, shard-0.1.2, xdist-3.3.1, cpp-2.3.0, rerunfailures-14.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 51 items
Running 51 items in this shard

test_fast_hadamard_transform.py ...................................................                                                                  [100%]

============================================================== 51 passed in 71.87s (0:01:11) ===============================================================
root@4ba3a2f2f1b5:/sgl-workspace/fast-hadamard-transform/tests#
```

#### MUSA 4.3.0 + Torch 2.5.0
```bash
root@worker3218:/ws# python setup.py install
/usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]


torch.__version__  = 2.5.0


running install
/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` directly.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
        ********************************************************************************

!!
  self.initialize_options()
/usr/local/lib/python3.10/dist-packages/setuptools/_distutils/cmd.py:66: EasyInstallDeprecationWarning: easy_install command is deprecated.
!!

        ********************************************************************************
        Please avoid running ``setup.py`` and ``easy_install``.
        Instead, use pypa/build, pypa/installer or other
        standards-based tools.

        See https://github.com/pypa/setuptools/issues/917 for details.
        ********************************************************************************

!!
  self.initialize_options()
running bdist_egg
running egg_info
writing fast_hadamard_transform.egg-info/PKG-INFO
writing dependency_links to fast_hadamard_transform.egg-info/dependency_links.txt
writing requirements to fast_hadamard_transform.egg-info/requires.txt
writing top-level names to fast_hadamard_transform.egg-info/top_level.txt
adding license file 'LICENSE'
adding license file 'AUTHORS'
writing manifest file 'fast_hadamard_transform.egg-info/SOURCES.txt'
installing library code to build/bdist.linux-x86_64/egg
running install_lib
running build_py
copying fast_hadamard_transform/fast_hadamard_transform_interface.py -> build/lib.linux-x86_64-cpython-310/fast_hadamard_transform
copying fast_hadamard_transform/__init__.py -> build/lib.linux-x86_64-cpython-310/fast_hadamard_transform
running build_ext
building 'fast_hadamard_transform_cuda' extension
Emitting ninja build file /ws/build/temp.linux-x86_64-cpython-310/build.ninja...
Compiling objects...
Using envvar MAX_JOBS (128) as the number of workers...
[1/2] /usr/local/musa/bin/mcc -x musa -MMD -MF /ws/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform.o.d -I/ws -I/usr/local/musa/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/aten/src -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/torch_musa_codegen -I/usr/local/lib/python3.10/dist-packages -I/usr/local/musa/include -I/usr/include/python3.10 -c -c /ws/csrc/fast_hadamard_transform.cpp -o /ws/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform.o -fPIC -O3 -fPIC -std=c++17 -x musa -mtgpu --cuda-gpu-arch=mp_31 -fno-strict-aliasing -ffast-math -Od3 -fmusa-flush-denormals-to-zero -DUSE_MUSA=1 --offload-arch=mp_31 -march=native -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=fast_hadamard_transform_cuda -D_GLIBCXX_USE_CXX11_ABI=1
[2/2] /usr/local/musa/bin/mcc -x musa -MMD -MF /ws/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform_gpu.o.d -I/ws -I/usr/local/musa/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/aten/src -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/torch/csrc/api/include -I/usr/local/lib/python3.10/dist-packages/torch_musa/share/torch_musa_codegen -I/usr/local/lib/python3.10/dist-packages -I/usr/local/musa/include -I/usr/include/python3.10 -c -c /ws/csrc/fast_hadamard_transform_gpu.cu -o /ws/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform_gpu.o -fPIC -O3 -fPIC -std=c++17 -x musa -mtgpu --cuda-gpu-arch=mp_31 -fno-strict-aliasing -ffast-math -Od3 -fmusa-flush-denormals-to-zero -DUSE_MUSA=1 --offload-arch=mp_31 -march=native -DTORCH_API_INCLUDE_EXTENSION_H '-DPYBIND11_COMPILER_TYPE="_gcc"' '-DPYBIND11_STDLIB="_libstdcpp"' '-DPYBIND11_BUILD_ABI="_cxxabi1016"' -DTORCH_EXTENSION_NAME=fast_hadamard_transform_cuda -D_GLIBCXX_USE_CXX11_ABI=1
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/InlineDeviceGuard.h:8:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:114:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:123:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:133:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:182:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:197:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:231:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Layout.h:3:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Backend.h:143:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Backend.h:282:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:5:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Layout.h:76:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:6:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/MemoryFormat.h:61:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymIntArrayRef.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymInt.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymBool.h:3:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:35:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:38:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:41:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:47:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:50:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:53:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:57:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:67:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:77:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:83:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:86:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:89:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:92:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:95:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:98:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:101:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:104:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:107:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:110:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:113:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:116:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:119:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:122:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:125:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:128:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:134:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:139:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:144:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:149:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:154:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:159:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:162:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:165:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:168:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:171:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:174:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:177:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:180:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:183:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:201:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:204:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:207:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:210:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:4:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/ScalarType.h:343:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/ScalarType.h:486:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/ScalarType.h:526:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:6:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/TensorOptions.h:724:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/TensorOptions.h:769:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Storage.h:6:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/StorageImpl.h:9:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyObjectSlot.h:125:3: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  }
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/Generator.h:18:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/GeneratorImpl.h:8:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/TensorImpl.h:1057:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:10:
/usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSACachingAllocator.h:214:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSACachingAllocator.h:223:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
62 warnings generated when compiling for mp_31.
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/InlineDeviceGuard.h:8:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:114:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:123:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:133:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:182:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:197:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/DeviceGuardImplInterface.h:231:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Layout.h:3:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Backend.h:143:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Backend.h:282:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:5:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Layout.h:76:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:6:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/MemoryFormat.h:61:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:5:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/GPUTrace.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyInterpreter.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymIntArrayRef.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymInt.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymBool.h:3:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:35:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:38:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:41:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:47:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:50:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:53:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:57:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:67:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:77:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:83:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:86:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:89:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:92:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:95:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:98:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:101:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:104:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:107:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:110:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:113:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:116:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:119:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:122:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:125:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:128:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:134:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:139:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:144:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:149:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:154:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:159:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:162:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:165:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:168:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:171:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:174:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:177:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:180:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:183:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:201:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:204:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:207:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/SymNodeImpl.h:210:3: warning: non-void function does not return a value [-Wreturn-type]
  };
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:4:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/ScalarType.h:343:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/ScalarType.h:486:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/ScalarType.h:526:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:6:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/TensorOptions.h:724:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/TensorOptions.h:769:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
}
^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/Storage.h:6:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/StorageImpl.h:9:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/impl/PyObjectSlot.h:125:3: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  }
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/aten/utils/Utils.h:4:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/Dispatch.h:3:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/DeprecatedTypeProperties.h:9:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/ATen/core/Generator.h:18:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/GeneratorImpl.h:8:
/usr/local/lib/python3.10/dist-packages/torch_musa/share/generated_cuda_compatible/include/c10/core/TensorImpl.h:1057:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
In file included from /ws/csrc/fast_hadamard_transform_gpu.cu:15:
In file included from /ws/csrc/vendor.h:24:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSAGuard.h:7:
In file included from /usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/GuardImpl.h:10:
/usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSACachingAllocator.h:214:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
/usr/local/lib/python3.10/dist-packages/torch_musa/csrc/core/MUSACachingAllocator.h:223:3: warning: non-void function does not return a value [-Wreturn-type]
  }
  ^
62 warnings generated when compiling for host.
x86_64-linux-gnu-g++ -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -g -fwrapv -O2 /ws/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform.o /ws/build/temp.linux-x86_64-cpython-310/csrc/fast_hadamard_transform_gpu.o -L/usr/local/lib/python3.10/dist-packages/torch/lib -L/usr/local/lib/python3.10/dist-packages/torch_musa/lib -L/usr/local/musa/lib -L/usr/lib/x86_64-linux-gnu -lc10 -ltorch -ltorch_cpu -ltorch_python -lmusa_python -o build/lib.linux-x86_64-cpython-310/fast_hadamard_transform_cuda.cpython-310-x86_64-linux-gnu.so -Wl,-rpath,$ORIGIN/lib -Wl,-rpath,/usr/local/lib/python3.10/dist-packages/torch/lib -Wl,-rpath,/usr/local/lib/python3.10/dist-packages/torch_musa/lib
creating build/bdist.linux-x86_64/egg
copying build/lib.linux-x86_64-cpython-310/fast_hadamard_transform_cuda.cpython-310-x86_64-linux-gnu.so -> build/bdist.linux-x86_64/egg
creating build/bdist.linux-x86_64/egg/fast_hadamard_transform
copying build/lib.linux-x86_64-cpython-310/fast_hadamard_transform/fast_hadamard_transform_interface.py -> build/bdist.linux-x86_64/egg/fast_hadamard_transform
copying build/lib.linux-x86_64-cpython-310/fast_hadamard_transform/__init__.py -> build/bdist.linux-x86_64/egg/fast_hadamard_transform
byte-compiling build/bdist.linux-x86_64/egg/fast_hadamard_transform/fast_hadamard_transform_interface.py to fast_hadamard_transform_interface.cpython-310.pyc
byte-compiling build/bdist.linux-x86_64/egg/fast_hadamard_transform/__init__.py to __init__.cpython-310.pyc
creating stub loader for fast_hadamard_transform_cuda.cpython-310-x86_64-linux-gnu.so
byte-compiling build/bdist.linux-x86_64/egg/fast_hadamard_transform_cuda.py to fast_hadamard_transform_cuda.cpython-310.pyc
creating build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/PKG-INFO -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/SOURCES.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/dependency_links.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/requires.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
copying fast_hadamard_transform.egg-info/top_level.txt -> build/bdist.linux-x86_64/egg/EGG-INFO
writing build/bdist.linux-x86_64/egg/EGG-INFO/native_libs.txt
zip_safe flag not set; analyzing archive contents...
__pycache__.fast_hadamard_transform_cuda.cpython-310: module references __file__
creating 'dist/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg' and adding 'build/bdist.linux-x86_64/egg' to it
removing 'build/bdist.linux-x86_64/egg' (and everything under it)
Processing fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg
removing '/usr/local/lib/python3.10/dist-packages/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg' (and everything under it)
creating /usr/local/lib/python3.10/dist-packages/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg
Extracting fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg to /usr/local/lib/python3.10/dist-packages
Adding fast-hadamard-transform 1.0.4.post1 to easy-install.pth file

Installed /usr/local/lib/python3.10/dist-packages/fast_hadamard_transform-1.0.4.post1-py3.10-linux-x86_64.egg
Processing dependencies for fast-hadamard-transform==1.0.4.post1
Searching for ninja==1.11.1
Best match: ninja 1.11.1
Adding ninja 1.11.1 to easy-install.pth file
Installing ninja script to /usr/local/bin

Using /usr/local/lib/python3.10/dist-packages
Searching for packaging==24.2
Best match: packaging 24.2
Adding packaging 24.2 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for torch==2.5.0
Best match: torch 2.5.0
Adding torch 2.5.0 to easy-install.pth file
Installing convert-caffe2-to-onnx script to /usr/local/bin
Installing convert-onnx-to-caffe2 script to /usr/local/bin
Installing torchfrtrace script to /usr/local/bin
Installing torchrun script to /usr/local/bin

Using /usr/local/lib/python3.10/dist-packages
Searching for sympy==1.13.1
Best match: sympy 1.13.1
Adding sympy 1.13.1 to easy-install.pth file
Installing isympy script to /usr/local/bin

Using /usr/local/lib/python3.10/dist-packages
Searching for fsspec==2025.9.0
Best match: fsspec 2025.9.0
Adding fsspec 2025.9.0 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for jinja2==3.1.6
Best match: jinja2 3.1.6
Adding jinja2 3.1.6 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for networkx==3.4.2
Best match: networkx 3.4.2
Adding networkx 3.4.2 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for typing-extensions==4.15.0
Best match: typing-extensions 4.15.0
Adding typing-extensions 4.15.0 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for filelock==3.19.1
Best match: filelock 3.19.1
Adding filelock 3.19.1 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for mpmath==1.3.0
Best match: mpmath 1.3.0
Adding mpmath 1.3.0 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Searching for MarkupSafe==3.0.2
Best match: MarkupSafe 3.0.2
Adding MarkupSafe 3.0.2 to easy-install.pth file

Using /usr/local/lib/python3.10/dist-packages
Finished processing dependencies for fast-hadamard-transform==1.0.4.post1
root@worker3218:/ws# cd tests/
root@worker3218:/ws/tests# pytest test_fast_hadamard_transform.py 
================================================================= test session starts ==================================================================
platform linux -- Python 3.10.12, pytest-7.2.2, pluggy-1.6.0
rootdir: /ws
plugins: hypothesis-6.140.2, anyio-4.10.0
collected 51 items                                                                                                                                     

test_fast_hadamard_transform.py ...................................................                                                              [100%]

=================================================================== warnings summary ===================================================================
../../usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61
  /usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py:61: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
    import pynvml  # type: ignore[import]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 51 passed, 1 warning in 82.26s (0:01:22) =======================================================
root@worker3218:/ws/tests# 
```