### PR TITLE
fix sm100 cuda bare metal version condition

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ if not SKIP_CUDA_BUILD:
     if bare_metal_version >= Version("11.8"):
         cc_flag.append("-gencode")
         cc_flag.append("arch=compute_90,code=sm_90")
-    if bare_metal_version >= Version("12.8.1"):
+    if bare_metal_version >= Version("12.8"):
         cc_flag.append("-gencode")
         cc_flag.append("arch=compute_100,code=sm_100")
 


### PR DESCRIPTION
The `bare_metal_version` currently only captures two components (e.g., 12.8) instead of the full three-digit format (12.8.1). As a result, when comparing CUDA version 12.8.1 against Version("12.8"), the comparison incorrectly evaluates to False.

```
> 3rdparty/fast-hadamard-transform/setup.py(116)<module>()
-> if bare_metal_version >= Version("12.8"):
(Pdb) bare_metal_version
<Version('12.8')>
(Pdb) bare_metal_version >= Version("12.8.1")
False
```

This PR fix the above